### PR TITLE
Make alert component local storage key configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,22 @@ Whether the enter/exit animations for the alert is enabled.
 
 ---
 
+#### `localStorageKeyName`
+
+The key name for the local storage item that stores the alert dismissed state.
+
+| Required | Type     | Default                                   |
+| -------- | -------- | ----------------------------------------- |
+| False    | `string` | `"react-cookies-consent/alert-dismissed"` |
+
+#### Example
+
+```jsx
+<CookiesConsentAlert localStorageKeyName="my-test-key-name" />
+```
+
+---
+
 #### `placement`
 
 The placement of the alert on the screen.

--- a/src/features/alert/alert-root.tsx
+++ b/src/features/alert/alert-root.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, Variants } from 'framer-motion';
 import React from 'react';
 import { Container } from '../../components/Container';
 import { MotionBox } from '../../components/MotionBox';
+import { LocalStorageKeys } from '../../constants/settings';
 import { Theme, ThemeStyles } from '../../constants/types';
 import { useStore } from '../../services/zustand/store';
 
@@ -43,6 +44,13 @@ export type AlertRootProps = {
   enterExitAnimationEnabled?: boolean;
 
   /**
+   * The key name for the local storage item that stores the alert dismissed
+   * state.
+   * @default 'react-cookies-consent/alert-dismissed'
+   */
+  localStorageKeyName?: string;
+
+  /**
    * The placement of the alert on the screen.
    * @default 'bottom-center'
    */
@@ -63,6 +71,7 @@ export const AlertRoot = React.forwardRef<AlertRootRef, AlertRootProps>(
     {
       enterExitAnimation = 'from-bottom',
       enterExitAnimationEnabled = true,
+      localStorageKeyName = LocalStorageKeys.AlertDismissed,
       placement = 'bottom-center',
       theme = 'light',
       ...props
@@ -71,9 +80,15 @@ export const AlertRoot = React.forwardRef<AlertRootRef, AlertRootProps>(
   ) => {
     const store = useStore();
 
-    // Set the theme in the store when the component mounts.
+    // Update the store when the component mounts.
     React.useEffect(() => {
+      store.setAlertDismissedLocalStorageKeyName(localStorageKeyName);
       store.setAlertTheme(theme);
+
+      // This needs to happen last since this is what will show/hide the alert
+      store.setAlertDismissed(
+        localStorage.getItem(localStorageKeyName) === 'true'
+      );
     }, []);
 
     // Create an imperative handle to handle actions the user can perform

--- a/src/services/zustand/store.ts
+++ b/src/services/zustand/store.ts
@@ -3,26 +3,74 @@ import { LocalStorageKeys } from '../../constants/settings';
 import { Theme } from '../../constants/types';
 
 export type ZustandStore = {
+  /**
+   * Whether the alert has been dismissed or not.
+   */
   alertDismissed: boolean;
+
+  /**
+   * Sets the alert dismissed state.
+   */
   setAlertDismissed: (dismissed: boolean) => void;
 
+  /**
+   * The key name for the local storage item that stores the alert dismissed
+   * state.
+   */
+  alertDismissedLocalStorageKeyName: string;
+
+  /**
+   * Sets the key name for the local storage item that stores the alert
+   * dismissed state.
+   */
+  setAlertDismissedLocalStorageKeyName: (keyName: string) => void;
+
+  /**
+   * The theme of the alert.
+   */
   alertTheme: Theme;
+
+  /**
+   * Sets the theme of the alert.
+   */
   setAlertTheme: (theme: Theme) => void;
 
+  /**
+   * Whether the modal is shown or not.
+   */
   modalShown: boolean;
+
+  /**
+   * Sets the modal shown state.
+   */
   setModalShown: (shown: boolean) => void;
 
+  /**
+   * The theme of the modal.
+   */
   modalTheme: Theme;
+
+  /**
+   * Sets the theme of the modal.
+   */
   setModalTheme: (theme: Theme) => void;
 };
 
 export const useStore = create<ZustandStore>()((set) => ({
-  alertDismissed:
-    localStorage.getItem(LocalStorageKeys.AlertDismissed) === 'true',
+  alertDismissed: true,
   setAlertDismissed: (dismissed) => {
-    localStorage.setItem(LocalStorageKeys.AlertDismissed, String(dismissed));
-    set({ alertDismissed: dismissed });
+    set((state) => {
+      localStorage.setItem(
+        state.alertDismissedLocalStorageKeyName,
+        String(dismissed)
+      );
+      return { alertDismissed: dismissed };
+    });
   },
+
+  alertDismissedLocalStorageKeyName: LocalStorageKeys.AlertDismissed,
+  setAlertDismissedLocalStorageKeyName: (keyName) =>
+    set({ alertDismissedLocalStorageKeyName: keyName }),
 
   alertTheme: 'light',
   setAlertTheme: (theme) => set({ alertTheme: theme }),


### PR DESCRIPTION
This adds a new prop to the alert root component named `localStorageKeyName` that will configure the local storage key name that stores whether or not the alert is dismissed. This change required documentation updates, too.

Example:

```jsx
<CookiesConsentAlert localStorageKeyName="my-test-key-name" />
```

I also added docstring to the Zustand store types.