### PR TITLE
Fix light/dark theme styles not changing fully when `theme` prop changes

### DIFF
--- a/src/features/alert/alert-root.tsx
+++ b/src/features/alert/alert-root.tsx
@@ -80,19 +80,23 @@ export const AlertRoot = React.forwardRef<AlertRootRef, AlertRootProps>(
   ) => {
     const store = useStore();
 
-    // Update the store when the component mounts.
+    // Update the stored theme when the theme prop changes
+    React.useEffect(() => {
+      store.setAlertTheme(theme);
+    }, [theme]);
+
+    // Update the stored alert state when the appropriate props change
     React.useEffect(() => {
       store.setAlertDismissedLocalStorageKeyName(localStorageKeyName);
-      store.setAlertTheme(theme);
 
       // This needs to happen last since this is what will show/hide the alert
       store.setAlertDismissed(
         localStorage.getItem(localStorageKeyName) === 'true'
       );
-    }, []);
+    }, [localStorageKeyName]);
 
     // Create an imperative handle to handle actions the user can perform
-    // on the alert.
+    // on the alert
     React.useImperativeHandle(
       ref,
       () => ({

--- a/src/features/modal/modal-root.tsx
+++ b/src/features/modal/modal-root.tsx
@@ -106,10 +106,10 @@ export const ModalRoot = React.forwardRef<ModalRootRef, ModalRootProps>(
   ) => {
     const store = useStore();
 
-    // Set the theme in the store when the component mounts.
+    // Update the stored theme when the theme prop changes
     React.useEffect(() => {
       store.setModalTheme(theme);
-    }, []);
+    }, [theme]);
 
     // Create an imperative handle to handle actions the user can perform
     // on the modal.


### PR DESCRIPTION
## Description

Whenever the `theme` prop changes on the alert or modal root components, we use a `useEffect` to make sure the store is updated with the new values.

## Testing

N/a